### PR TITLE
fix: ignore create connection types

### DIFF
--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -67,6 +67,7 @@ class Libp2pAgent extends NodeAgent {
     this.peer = init.peer
   }
 
+  // @ts-expect-error types are wrong
   createConnection (options: TcpNetConnectOpts, cb: (err?: Error, socket?: Socket) => void): void {
     createConnection(this.components.connectionManager, this.peer, options)
       .then(socket => {
@@ -88,6 +89,7 @@ export class HTTP extends HTTPBrowser implements HTTPInterface {
       return new NodeAgent(options)
     }
 
+    // @ts-expect-error types are wrong
     return new Libp2pAgent(this.components, {
       ...options,
       peer


### PR DESCRIPTION
If we make the implementation match the types then errors start to occur so add ignores for now.


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works